### PR TITLE
Add lsp-mode to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To [install and run](#installation-instructions) this language server, you will 
 - [atom-ide-docker](https://github.com/josa42/atom-ide-docker)
 - [Sourcegraph](https://sourcegraph.com/)
 - [Theia](https://theia-ide.org/)
+- [lsp-mode](https://emacs-lsp.github.io/lsp-mode/)
 
 This repository only contains the code necessary for launching a Dockerfile language server that conforms to the language server protocol.
 The actual code for parsing a Dockerfile and offering editor features such as code completion or hovers is not contained within this repository.


### PR DESCRIPTION
Emacs also support dockerfile-language-server with [lsp-mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-dockerfile/), so add it to the README may be useful.